### PR TITLE
Fix icon ImageResponse import for Next.js 15

### DIFF
--- a/src/app/icon.js
+++ b/src/app/icon.js
@@ -1,4 +1,4 @@
-import { ImageResponse } from "next/server";
+import { ImageResponse } from "next/og";
 
 export const size = {
   width: 64,


### PR DESCRIPTION
## Summary
- update the app icon route to import `ImageResponse` from `next/og` so it is compatible with Next.js 14+

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8c818dc408326b6cecf93661588a1